### PR TITLE
Update index.h

### DIFF
--- a/src/index.h
+++ b/src/index.h
@@ -5,6 +5,7 @@
 #include <string>
 #include <vector>
 #include <cstdint>
+#include <memory>
 
 static constexpr unsigned ZSTD_indexTableFooterSize = 9;
 static constexpr uint32_t ZSTD_FIDX_MAGICNUMBER = 0x46494458; // 'FIDX'


### PR DESCRIPTION
compatibility with recent gcc (>=11), fixes "error: ‘unique_ptr’ is not a member of ‘std’"